### PR TITLE
fix: remove duplicate nanoid@3.3.18 from pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2874,11 +2874,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -6148,8 +6143,6 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-
-  nanoid@3.3.18: {}
 
   nanoid@3.3.18: {}
 


### PR DESCRIPTION
## Summary
- Removes duplicate `nanoid@3.3.18` entries in `pnpm-lock.yaml` (packages + snapshots sections)
- Root cause: PR #4 (Next 15.5.21) and PR #14 (postcss) landed 14s apart and both added the same lockfile key, producing invalid YAML
- `pnpm install --frozen-lockfile --ignore-scripts` now succeeds locally

## Test plan
- [x] `pnpm install --frozen-lockfile --ignore-scripts` passes
- [ ] Docker build on main succeeds after merge